### PR TITLE
Pgeo maintenance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Environment variables for HII OSM CSV task following the Environment Variables section in the README.md.
+# Copy this file to .env and fill in the values.
+# Do NOT commit the .env file to version control.
+
+# The JSON content of your Google Cloud service account key, enclosed in single quotes.
+# This is required for uploading results to Google Cloud Storage.
+# Example: SERVICE_ACCOUNT_KEY='{"type": "service_account", ...}'
+SERVICE_ACCOUNT_KEY={}
+
+# The Google Cloud Storage bucket to upload results to.
+# Defaults to 'hii-osm' if not set in the script.
+HII_OSM_BUCKET=hii-osm
+
+# You can also override other command-line arguments here.
+# For example, to run for a specific date:
+# taskdate=2023-01-01

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# vscode dev containers
+.devcontainer
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ HII OSM Ingest
 3. Group bands from imported images into a single image
 4. Clean split images
 
-
 ## Environment Variables
 
 ```
@@ -35,6 +34,40 @@ optional arguments:
   --skip_cleanup        Skip cleaning up temporary task files (default: False)
   --output_image OUTPUT_IMAGE
                         Custom output EE image name (default: None)
+```
+
+## Google Cloud VM Setup
+1. In the Cloud Console navigate to Compute Engine > VM Instances
+
+2. Find the VM named 'task-hii-osm-ingest' and click 'SSH' to enter into the VM in your browswer
+
+3. Once inside the VM, check for necessary installed software that should be already installed. Copy and paste this block of commands into the terminal and hit enter
+
+```bash
+git --version
+docker --version
+make --version
+```
+
+5. Copy and paste this block of commands into terminal and hit enter:
+
+```bash
+git clone --branch pgeo-maintenance https://github.com/SpeciesConservationLandscapes/task_hii_osm_ingest.git
+cd task_hii_osm_ingest
+sudo make build
+```
+6. To enter into the task's docker container, it needs an environment file (.env) to pass in. Save-as the [.env.example](.env.example) file to a new file called .env. You will need to paste in the google cloud service account key info for the service account that runs the code on our behalf. See ... for more details.
+
+7. Once your .env file is filled out, run:
+
+```bash
+sudo make shell
+```
+
+8. You should now be inside the built docker container. Finally, run a task for your chosen task date, i.e.
+
+```python
+python task.py -d 2025-12-31 -m gs://hii-osm/2025-12-31/metadata.json
 ```
 
 ### License

--- a/src/inspector.py
+++ b/src/inspector.py
@@ -1,9 +1,12 @@
+# allows to run HIIOSMIngest task with a python debugger for future maintenance..
+# if you know you know
 from task import HIIOSMIngest
 options = {
-    "taskdate": "2012-12-31", # setting this further back to test self.population_density property bug
-    "metadata": "gs://hii-osm/2012-12-31/metadata.json", # this is what actually controls what OSM data you're processing
+    "taskdate": "2021-12-31", # setting this further back to test self.population_density property bug
+    "metadata": "gs://hii-osm/2021-12-31/metadata.json", # this is what actually controls what OSM data you're processing
     # "skip_cleanup": True,
-    "output_image": "osm_kyle_test_guatemala2"
+    "import_roads": True,
+    "output_image": "osm_kyle_test_belize"
 }
 task = HIIOSMIngest(**options)
 task.run()

--- a/src/inspector.py
+++ b/src/inspector.py
@@ -1,0 +1,9 @@
+from task import HIIOSMIngest
+options = {
+    "taskdate": "2012-12-31", # setting this further back to test self.population_density property bug
+    "metadata": "gs://hii-osm/2012-12-31/metadata.json", # this is what actually controls what OSM data you're processing
+    # "skip_cleanup": True,
+    "output_image": "osm_kyle_test_guatemala2"
+}
+task = HIIOSMIngest(**options)
+task.run()

--- a/src/task.py
+++ b/src/task.py
@@ -25,6 +25,8 @@ class HIIOSMIngest(HIITask):
 
     DEFAULT_BUCKET = os.environ.get("HII_OSM_BUCKET", "hii-osm")
     ee_osm_root = "osm"
+    asset_prefix = f"projects/{HIITask.ee_project}/assets/{ee_osm_root}"
+
     
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)
@@ -37,6 +39,11 @@ class HIIOSMIngest(HIITask):
         self.skip_cleanup = (
             kwargs.get("skip_cleanup") or os.environ.get("skip_cleanup") or False
         )
+        
+        self.import_roads = (
+            kwargs.get("import_roads") or os.environ.get("import_roads") or False
+        )
+        
         self.output_image = (
             kwargs.get("output_image") or os.environ.get("output_image") or "osm_image"
         )
@@ -74,7 +81,7 @@ class HIIOSMIngest(HIITask):
         image_asset_ids = []
         for image_uri in image_uris:
             image_asset_id = self._uri_to_asset_id(image_uri)
-            task_id = self.storage2image(image_uri, image_asset_id, nodataval=0)
+            # task_id = self.storage2image(image_uri, image_asset_id, nodataval=0)
             image_asset_ids.append(image_asset_id)
 
         self.wait()
@@ -117,6 +124,7 @@ class HIIOSMIngest(HIITask):
 
         img_col = ee.ImageCollection(bands.map(band_merge))
         img = img_col.toBands().rename(band_names)
+        img = img.set("osm_url",metadata.get("osm_url"))
         asset_path = f"{self.ee_osm_root}/{self.output_image}"
         self.export_image_ee(img, asset_path, image_collection=True)
         
@@ -145,12 +153,11 @@ class HIIOSMIngest(HIITask):
             with Timer("Group image bands"):
                 self.group_bands(image_asset_ids, metadata)
 
-            # with Timer("Import roads table Storage to EE table"):
-            #     osm_roads_dir = f"{self.ee_osm_root}/roads"
-            #     roads_dir = f"{PROJECTS}/{self.ee_project}/{osm_roads_dir}"
-            #     self._prep_asset_id(osm_roads_dir)
-            #     roads_asset_id = f"{roads_dir}/roads_{self.taskdate}"
-            #     self.import_roads_to_ee(metadata["road"], roads_asset_id)
+            # if self.import_roads:
+            #     with Timer("Import roads table Storage to EE table"):
+            #         roads_asset_dir = f"{self.ee_osm_root}/roads"
+            #         _, roads_asset_id = self._prep_asset_id(roads_asset_dir)
+            #         self.import_roads_to_ee(metadata["road"], roads_asset_id)
 
         finally:
             with Timer("Clean up"):
@@ -178,6 +185,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Skip cleaning up temporary task files",
     )
+    parser.add_argument(
+        "--import_roads",
+        action="store_true",
+        help="import roads .csv from cloud storage to GEE"
+    )
+    
     parser.add_argument(
         "--output_image",
         type=str,


### PR DESCRIPTION
* update README and add a template `.env.example` file to give users more instruction for set up
* add doc-strings and helpful in-line code documentation to `task.py` for others who come along later
* edit earth engine path construction utilities to work for cloud-backed assets not legacy
* make import of roads csv to ee.FeatureCollection a CLI arg option